### PR TITLE
Updated GetTransactionHistory to send time as nanoseconds

### DIFF
--- a/CryptoCom.Net/Clients/ExchangeApi/CryptoComRestClientExchangeApiAccount.cs
+++ b/CryptoCom.Net/Clients/ExchangeApi/CryptoComRestClientExchangeApiAccount.cs
@@ -120,8 +120,8 @@ namespace CryptoCom.Net.Clients.ExchangeApi
             var parameters = new ParameterCollection();
             parameters.AddOptional("instrument_name", symbol);
             parameters.AddOptionalEnum("journal_type", transactionType);
-            parameters.AddOptional("start_time", DateTimeConverter.ConvertToNanoseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptional("end_time", DateTimeConverter.ConvertToNanoseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
+            parameters.AddOptional("start_time", DateTimeConverter.ConvertToNanoseconds(startTime));
+            parameters.AddOptional("end_time", DateTimeConverter.ConvertToNanoseconds(endTime));
             parameters.AddOptional("limit", limit);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "private/get-transactions", CryptoComExchange.RateLimiter.RestPrivate, 1, true);
             var result = await _baseClient.SendAsync<CryptoComTransactionWrapper>(request, parameters, ct).ConfigureAwait(false);

--- a/CryptoCom.Net/Clients/ExchangeApi/CryptoComRestClientExchangeApiAccount.cs
+++ b/CryptoCom.Net/Clients/ExchangeApi/CryptoComRestClientExchangeApiAccount.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
+using CryptoExchange.Net.Converters.SystemTextJson;
 using CryptoCom.Net.Objects.Models;
 using System;
 using CryptoCom.Net.Enums;
@@ -118,8 +119,8 @@ namespace CryptoCom.Net.Clients.ExchangeApi
             var parameters = new ParameterCollection();
             parameters.AddOptional("instrument_name", symbol);
             parameters.AddOptionalEnum("journal_type", transactionType);
-            parameters.AddOptionalMillisecondsString("start_time", startTime);
-            parameters.AddOptionalMillisecondsString("end_time", endTime);
+            parameters.AddOptional("start_time", DateTimeConverter.ConvertToNanoseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
+            parameters.AddOptional("end_time", DateTimeConverter.ConvertToNanoseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
             parameters.AddOptional("limit", limit);
             var request = _definitions.GetOrCreate(HttpMethod.Post, "private/get-transactions", CryptoComExchange.RateLimiter.RestPrivate, 1, true);
             var result = await _baseClient.SendAsync<CryptoComTransactionWrapper>(request, parameters, ct).ConfigureAwait(false);

--- a/CryptoCom.Net/Clients/ExchangeApi/CryptoComRestClientExchangeApiAccount.cs
+++ b/CryptoCom.Net/Clients/ExchangeApi/CryptoComRestClientExchangeApiAccount.cs
@@ -8,6 +8,7 @@ using CryptoExchange.Net.Converters.SystemTextJson;
 using CryptoCom.Net.Objects.Models;
 using System;
 using CryptoCom.Net.Enums;
+using System.Globalization;
 
 namespace CryptoCom.Net.Clients.ExchangeApi
 {


### PR DESCRIPTION
Changed the `start_time` and `end_time` parameters in the `GetTransactionHistoryAsync` method to use nanoseconds instead of milliseconds for a more accurate pagination.
(Also recommended in the docs: https://exchange-docs.crypto.com/exchange/v1/rest-ws/index.html#private-get-transactions)